### PR TITLE
docs: Remove untested stdio transport instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,154 +1,134 @@
 # Letta MCP Server
 
-This directory contains the reorganized Letta MCP server code with a more logical structure.
+A server that provides tools for agent management, memory operations, and integration with the Letta system.
+
+## Quick Setup
+
+### Option 1: Run with Node.js
+
+```bash
+# Development (with hot reload)
+npm run dev:sse     # SSE transport
+
+# Production
+npm run build       # Build TypeScript first
+npm run start:sse   # SSE transport
+```
+
+### Option 2: Run with Docker
+
+```bash
+# Build and run locally
+docker build -t letta-mcp-server .
+docker run -d -p 3001:3001 -e PORT=3001 -e NODE_ENV=production --name letta-mcp letta-mcp-server
+
+# Or use the public image
+docker run -d -p 3001:3001 -e PORT=3001 -e NODE_ENV=production --name letta-mcp ghcr.io/oculairmedia/letta-mcp-server:latest
+```
 
 ## Directory Structure
 
+- index.js - Main entry point
 - `core/` - Core server functionality
-  - `server.js` - Main server class with initialization and API communication
-
 - `tools/` - Individual tool implementations
-  - Contains various tool implementations for agent management, memory operations, and more
-  - `index.js` - Exports all tool definitions and handlers
+- `transports/` - Server transport implementations (stdio and SSE)
 
-- `transports/` - Server transport implementations
-  - `stdio-transport.js` - StdioServerTransport implementation
-  - `sse-transport.js` - SSEServerTransport implementation
-  - `index.js` - Exports all transport handlers
+## Available Tools
 
-- `index.js` - Main entry point that initializes and runs the server
+### Agent Management
 
-## Available MCP Tools
+| Tool | Description | Required Parameters | Optional Parameters |
+|------|-------------|---------------------|---------------------|
+| `create_agent` | Create a new Letta agent | name, description | model, embedding |
+| `list_agents` | List all available agents | - | filter |
+| `prompt_agent` | Send a message to an agent | agent_id, message | - |
+| `get_agent` | Get agent details by ID | agent_id | - |
+| `modify_agent` | Update an existing agent | agent_id, update_data | - |
+| `delete_agent` | Delete an agent | agent_id | - |
+| `clone_agent` | Clone an existing agent | source_agent_id, new_agent_name | override_existing_tools, project_id |
+| `bulk_delete_agents` | Delete multiple agents | - | agent_ids, agent_name_filter, agent_tag_filter |
 
-### Agent Management Tools
+### Memory Management
 
-- `create_agent` - Create a new Letta agent with specified configuration
-  - Required: name (string), description (string)
-  - Optional: model (string, default: 'openai/gpt-4'), embedding (string, default: 'openai/text-embedding-ada-002')
+| Tool | Description | Required Parameters | Optional Parameters |
+|------|-------------|---------------------|---------------------|
+| `list_memory_blocks` | List all memory blocks | - | filter, agent_id, page, pageSize, label |
+| `create_memory_block` | Create a new memory block | name, label, value | agent_id, metadata |
+| `read_memory_block` | Read a memory block | block_id | agent_id |
+| `update_memory_block` | Update a memory block | block_id | value, metadata, agent_id |
+| `attach_memory_block` | Attach memory to an agent | block_id, agent_id | label |
 
-- `list_agents` - List all available agents in the Letta system
-  - Optional: filter (string) - Filter to search for specific agents
+### Tool Management
 
-- `prompt_agent` - Send a message to an agent and get a response
-  - Required: agent_id (string), message (string)
+| Tool | Description | Required Parameters | Optional Parameters |
+|------|-------------|---------------------|---------------------|
+| `list_tools` | List all available tools | - | filter, page, pageSize |
+| `list_agent_tools` | List tools for a specific agent | agent_id | - |
+| `attach_tool` | Attach tools to an agent | agent_id | tool_id, tool_ids, tool_names |
+| `upload_tool` | Upload a new tool | name, description, source_code | category, agent_id |
+| `bulk_attach_tool_to_agents` | Attach a tool to multiple agents | tool_id | agent_name_filter, agent_tag_filter |
 
-- `retrieve_agent` - Get the state of a specific agent by ID
-  - Required: agent_id (string)
+### Additional Tools
 
-- `modify_agent` - Update an existing agent by ID with provided data
-  - Required: agent_id (string), update_data (object)
+- **Model Management**: `list_llm_models`, `list_embedding_models`
+- **Archive Management**: `list_passages`, `create_passage`, `modify_passage`, `delete_passage`
+- **MCP Server Management**: `list_mcp_servers`, `list_mcp_tools_by_server`
+- **Import/Export**: `export_agent`, `import_agent`
 
-- `delete_agent` - Delete a specific agent by ID
-  - Required: agent_id (string)
-
-- `clone_agent` - Create a new agent by cloning an existing one
-  - Required: source_agent_id (string), new_agent_name (string)
-  - Optional: override_existing_tools (boolean), project_id (string)
-
-- `get_agent_summary` - Get a concise summary of an agent's configuration
-  - Required: agent_id (string)
-
-- `bulk_delete_agents` - Delete multiple agents based on criteria
-  - Optional: agent_ids (string[]), agent_name_filter (string), agent_tag_filter (string)
-
-### Memory Management Tools
-
-- `list_memory_blocks` - List all memory blocks in the system
-  - Optional: filter (string), agent_id (string), page (number), pageSize (number), label (string)
-
-- `create_memory_block` - Create a new memory block
-  - Required: name (string), label (string), value (string)
-  - Optional: agent_id (string), metadata (object)
-
-- `read_memory_block` - Get details of a specific memory block
-  - Required: block_id (string)
-  - Optional: agent_id (string)
-
-- `update_memory_block` - Update contents/metadata of a memory block
-  - Required: block_id (string)
-  - Optional: value (string), metadata (object), agent_id (string)
-
-- `attach_memory_block` - Attach a memory block to an agent
-  - Required: block_id (string), agent_id (string)
-  - Optional: label (string)
-
-### Tool Management Tools
-
-- `list_tools` - List all available tools on the Letta server
-  - Optional: filter (string), page (number), pageSize (number)
-
-- `list_agent_tools` - List tools available for a specific agent
-  - Required: agent_id (string)
-
-- `attach_tool` - Attach tools to an agent
-  - Required: agent_id (string)
-  - Optional: tool_id (string), tool_ids (string[]), tool_names (string[])
-
-- `upload_tool` - Upload a new tool to the system
-  - Required: name (string), description (string), source_code (string)
-  - Optional: category (string), agent_id (string)
-
-- `bulk_attach_tool_to_agents` - Attach a tool to multiple agents
-  - Required: tool_id (string)
-  - Optional: agent_name_filter (string), agent_tag_filter (string)
-
-### Model Management Tools
-
-- `list_llm_models` - List available LLM models
-- `list_embedding_models` - List available embedding models
-
-### Passage/Archive Tools
-
-- `list_passages` - List memories in an agent's archival store
-  - Required: agent_id (string)
-  - Optional: after (string), before (string), limit (number), search (string)
-
-- `create_passage` - Create a new memory in archival store
-  - Required: agent_id (string), text (string)
-
-- `modify_passage` - Modify an existing memory
-  - Required: agent_id (string), memory_id (string), update_data (object)
-
-- `delete_passage` - Delete a memory from archival store
-  - Required: agent_id (string), memory_id (string)
-
-### MCP Server Tools
-
-- `list_mcp_servers` - List all configured MCP servers
-
-- `list_mcp_tools_by_server` - List available tools for a specific MCP server
-  - Required: mcp_server_name (string)
-  - Optional: filter (string), page (number), pageSize (number)
-
-- `export_agent` - Export an agent's configuration
-  - Required: agent_id (string)
-  - Optional: output_path (string), return_base64 (boolean), upload_to_xbackbone (boolean)
-
-- `import_agent` - Import an agent from configuration
-  - Required: file_path (string)
-  - Optional: append_copy_suffix (boolean), override_existing_tools (boolean)
-
-## Running the Server
-
-### Using JavaScript (Development)
+## Docker Operations
 
 ```bash
-# Run with stdio transport
-npm run dev
+# View container logs
+docker logs -f letta-mcp
 
-# Run with SSE transport
-npm run dev:sse
+# Stop the container
+docker stop letta-mcp
+
+# Update to latest version
+docker pull ghcr.io/oculairmedia/letta-mcp-server:latest
+docker stop letta-mcp
+docker rm letta-mcp
+docker run -d -p 3001:3001 -e PORT=3001 -e NODE_ENV=production --name letta-mcp ghcr.io/oculairmedia/letta-mcp-server:latest
 ```
 
-### Using TypeScript (Production)
+## Configuration with MCP Settings
 
-```bash
-# Build the TypeScript code
-npm run build
+Add the server to your mcp_settings.json:
 
-# Run with stdio transport
-npm run start
-
-# Run with SSE transport
-npm run start:sse
+```json
+"letta": {
+  "command": "node",
+  "args": [
+    "--no-warnings",
+    "--experimental-modules",
+    "path/to/letta-server/index.js"
+  ],
+  "env": {
+    "LETTA_BASE_URL": "https://your-letta-instance.com",
+    "LETTA_PASSWORD": "yourPassword"
+  },
+  "disabled": false,
+  "alwaysAllow": [
+    "upload_tool",
+    "attach_tool",
+    "list_agents",
+    "list_memory_blocks"
+  ],
+  "timeout": 300
+}
 ```
+
+For remote instances, use the URL configuration:
+
+```json
+"remote_letta_tools": {
+  "url": "http://your-server:3001/sse",
+  "disabled": false,
+  "alwaysAllow": [
+    "attach_tool", 
+    "list_agents",
+    "list_tools",
+    "get_agent"
+  ],
+  "timeout": 120
+}


### PR DESCRIPTION
This PR removes references to the untested stdio transport from the README, keeping only the verified SSE transport instructions.

Changes:
- Removed stdio transport commands from development and production sections
- Kept only SSE transport instructions
- Maintained all Docker-related documentation