### PR TITLE
feat: add delete_memory_block tool

### DIFF
--- a/src/test/tools/memory/delete-memory-block.test.js
+++ b/src/test/tools/memory/delete-memory-block.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    handleDeleteMemoryBlock,
+    deleteMemoryBlockToolDefinition,
+} from '../../../tools/memory/delete-memory-block.js';
+import { createMockLettaServer } from '../../utils/mock-server.js';
+import { expectValidToolResponse } from '../../utils/test-helpers.js';
+
+describe('Delete Memory Block', () => {
+    let mockServer;
+
+    beforeEach(() => {
+        mockServer = createMockLettaServer();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Tool Definition', () => {
+        it('should have correct tool definition', () => {
+            expect(deleteMemoryBlockToolDefinition.name).toBe('delete_memory_block');
+            expect(deleteMemoryBlockToolDefinition.description).toContain('Delete a memory block');
+            expect(deleteMemoryBlockToolDefinition.description).toContain('WARNING');
+            expect(deleteMemoryBlockToolDefinition.inputSchema.required).toEqual(['block_id']);
+            expect(deleteMemoryBlockToolDefinition.inputSchema.properties).toHaveProperty('block_id');
+            expect(deleteMemoryBlockToolDefinition.inputSchema.properties).toHaveProperty('agent_id');
+        });
+    });
+
+    describe('Functionality Tests', () => {
+        it('should delete memory block successfully', async () => {
+            mockServer.api.delete.mockResolvedValueOnce({ data: null });
+
+            const result = await handleDeleteMemoryBlock(mockServer, {
+                block_id: 'block-123',
+            });
+
+            expect(mockServer.api.delete).toHaveBeenCalledWith(
+                '/blocks/block-123',
+                expect.objectContaining({
+                    headers: expect.any(Object),
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.success).toBe(true);
+            expect(data.deleted_block_id).toBe('block-123');
+        });
+
+        it('should delete memory block with agent_id authorization', async () => {
+            const agentId = 'agent-456';
+            mockServer.api.delete.mockResolvedValueOnce({ data: null });
+
+            const result = await handleDeleteMemoryBlock(mockServer, {
+                block_id: 'agent-block-123',
+                agent_id: agentId,
+            });
+
+            expect(mockServer.api.delete).toHaveBeenCalledWith(
+                '/blocks/agent-block-123',
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        user_id: agentId,
+                    }),
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.success).toBe(true);
+            expect(data.deleted_block_id).toBe('agent-block-123');
+        });
+
+        it('should handle UUID format block IDs', async () => {
+            const uuidBlockId = '550e8400-e29b-41d4-a716-446655440000';
+            mockServer.api.delete.mockResolvedValueOnce({ data: null });
+
+            const result = await handleDeleteMemoryBlock(mockServer, {
+                block_id: uuidBlockId,
+            });
+
+            expect(mockServer.api.delete).toHaveBeenCalledWith(
+                `/blocks/${uuidBlockId}`,
+                expect.any(Object),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.success).toBe(true);
+            expect(data.deleted_block_id).toBe(uuidBlockId);
+        });
+
+        it('should handle special characters in block_id', async () => {
+            const blockId = 'block-with-special_chars.123';
+            mockServer.api.delete.mockResolvedValueOnce({ data: null });
+
+            const result = await handleDeleteMemoryBlock(mockServer, {
+                block_id: blockId,
+            });
+
+            const data = expectValidToolResponse(result);
+            expect(data.success).toBe(true);
+            expect(data.deleted_block_id).toBe(blockId);
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('should throw error for missing block_id', async () => {
+            await expect(handleDeleteMemoryBlock(mockServer, {})).rejects.toThrow(
+                'Missing required argument: block_id',
+            );
+        });
+
+        it('should throw error for null block_id', async () => {
+            await expect(handleDeleteMemoryBlock(mockServer, { block_id: null })).rejects.toThrow(
+                'Missing required argument: block_id',
+            );
+        });
+
+        it('should throw error for undefined args', async () => {
+            await expect(handleDeleteMemoryBlock(mockServer, undefined)).rejects.toThrow(
+                'Missing required argument: block_id',
+            );
+        });
+
+        it('should throw error for empty string block_id', async () => {
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: '',
+                }),
+            ).rejects.toThrow('Missing required argument: block_id');
+        });
+
+        it('should handle 404 error when block not found', async () => {
+            const error = new Error('Not found');
+            error.response = {
+                status: 404,
+                data: { error: 'Memory block not found' },
+            };
+            mockServer.api.delete.mockRejectedValueOnce(error);
+
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: 'non-existent-block',
+                }),
+            ).rejects.toThrow('Not found');
+        });
+
+        it('should handle 401 unauthorized error', async () => {
+            const error = new Error('Unauthorized');
+            error.response = {
+                status: 401,
+                data: { error: 'Unauthorized access' },
+            };
+            mockServer.api.delete.mockRejectedValueOnce(error);
+
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: 'protected-block',
+                }),
+            ).rejects.toThrow('Unauthorized');
+        });
+
+        it('should handle 403 forbidden error', async () => {
+            const error = new Error('Forbidden');
+            error.response = {
+                status: 403,
+                data: { error: 'Cannot delete this block' },
+            };
+            mockServer.api.delete.mockRejectedValueOnce(error);
+
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: 'forbidden-block',
+                    agent_id: 'agent-no-access',
+                }),
+            ).rejects.toThrow('Forbidden');
+        });
+
+        it('should handle network errors', async () => {
+            const error = new Error('Network error: Connection refused');
+            mockServer.api.delete.mockRejectedValueOnce(error);
+
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: 'block-123',
+                }),
+            ).rejects.toThrow('Network error');
+        });
+
+        it('should handle server errors', async () => {
+            const error = new Error('Internal server error');
+            error.response = {
+                status: 500,
+                data: { error: 'Database error' },
+            };
+            mockServer.api.delete.mockRejectedValueOnce(error);
+
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: 'block-123',
+                }),
+            ).rejects.toThrow('Internal server error');
+        });
+
+        it('should handle 409 conflict error for blocks in use', async () => {
+            const error = new Error('Conflict');
+            error.response = {
+                status: 409,
+                data: { error: 'Block is currently attached to agents and cannot be deleted' },
+            };
+            mockServer.api.delete.mockRejectedValueOnce(error);
+
+            await expect(
+                handleDeleteMemoryBlock(mockServer, {
+                    block_id: 'in-use-block',
+                }),
+            ).rejects.toThrow('Conflict');
+        });
+    });
+});

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -33,6 +33,10 @@ import {
     handleCreateMemoryBlock,
     createMemoryBlockToolDefinition,
 } from './memory/create-memory-block.js';
+import {
+    handleDeleteMemoryBlock,
+    deleteMemoryBlockToolDefinition,
+} from './memory/delete-memory-block.js';
 
 // Passage-related imports
 import { handleListPassages, listPassagesDefinition } from './passages/list-passages.js';
@@ -95,6 +99,7 @@ export function registerToolHandlers(server) {
         updateMemoryBlockToolDefinition,
         attachMemoryBlockToolDefinition,
         createMemoryBlockToolDefinition,
+        deleteMemoryBlockToolDefinition,
         uploadToolToolDefinition,
         listMcpToolsByServerDefinition,
         listMcpServersDefinition,
@@ -149,6 +154,8 @@ export function registerToolHandlers(server) {
                 return handleAttachMemoryBlock(server, request.params.arguments);
             case 'create_memory_block':
                 return handleCreateMemoryBlock(server, request.params.arguments);
+            case 'delete_memory_block':
+                return handleDeleteMemoryBlock(server, request.params.arguments);
             case 'upload_tool':
                 return handleUploadTool(server, request.params.arguments);
             case 'list_mcp_tools_by_server':
@@ -212,6 +219,7 @@ export const toolDefinitions = enhanceAllTools([
     updateMemoryBlockToolDefinition,
     attachMemoryBlockToolDefinition,
     createMemoryBlockToolDefinition,
+    deleteMemoryBlockToolDefinition,
     uploadToolToolDefinition,
     listMcpToolsByServerDefinition,
     listMcpServersDefinition,
@@ -247,6 +255,7 @@ export const toolHandlers = {
     handleUpdateMemoryBlock,
     handleAttachMemoryBlock,
     handleCreateMemoryBlock,
+    handleDeleteMemoryBlock,
     handleUploadTool,
     handleListMcpToolsByServer,
     handleListMcpServers,

--- a/src/tools/memory/delete-memory-block.js
+++ b/src/tools/memory/delete-memory-block.js
@@ -1,0 +1,62 @@
+/**
+ * Tool handler for deleting a memory block in the Letta system
+ */
+export async function handleDeleteMemoryBlock(server, args) {
+    try {
+        // Validate arguments
+        if (!args?.block_id) {
+            throw new Error('Missing required argument: block_id');
+        }
+
+        // Headers for API requests
+        const headers = server.getApiHeaders();
+
+        // If agent_id is provided, set the user_id header
+        if (args.agent_id) {
+            headers['user_id'] = args.agent_id;
+        }
+
+        // Delete the memory block
+        await server.api.delete(`/blocks/${args.block_id}`, {
+            headers,
+        });
+
+        // Return success response
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: true,
+                        deleted_block_id: args.block_id,
+                    }),
+                },
+            ],
+        };
+    } catch (error) {
+        return server.createErrorResponse(error);
+    }
+}
+
+/**
+ * Tool definition for delete_memory_block
+ */
+export const deleteMemoryBlockToolDefinition = {
+    name: 'delete_memory_block',
+    description:
+        'Delete a memory block by ID. Use list_memory_blocks to find block IDs. WARNING: This action is permanent and cannot be undone.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            block_id: {
+                type: 'string',
+                description: 'ID of the memory block to delete',
+            },
+            agent_id: {
+                type: 'string',
+                description: 'Optional agent ID for authorization',
+            },
+        },
+        required: ['block_id'],
+    },
+};


### PR DESCRIPTION
## Summary

- Adds `delete_memory_block` tool to complete CRUD operations for memory blocks
- Follows existing patterns from `read-memory-block.js` for consistency
- Uses correct validation pattern (`throw new Error()` inside try block)

## Changes

- `src/tools/memory/delete-memory-block.js` - handler and tool definition
- `src/tools/index.js` - tool registration
- `src/test/tools/memory/delete-memory-block.test.js` - 15 unit tests

## Test Plan

- [x] Linter passes (`npm run lint`)
- [x] All tests pass (`npm test`) - 705 tests total
- [x] Tool definition validates correctly
- [x] Error handling follows established patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add memory block deletion: users can delete specific memory blocks (optionally on behalf of an agent) with clear success responses and robust handling for IDs with special characters.

* **Tests**
  * Added comprehensive test coverage for deletion flows, input validation (missing/null/empty IDs), authorization variants, HTTP errors (404/401/403/409/5xx) and network failures to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->