### PR TITLE
feat: add list_messages and create_conversation_entry tools

### DIFF
--- a/src/test/tools/messages/create-conversation-entry.test.js
+++ b/src/test/tools/messages/create-conversation-entry.test.js
@@ -1,0 +1,571 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    handleCreateConversationEntry,
+    createConversationEntryDefinition,
+} from '../../../tools/messages/create-conversation-entry.js';
+import { createMockLettaServer } from '../../utils/mock-server.js';
+import { expectValidToolResponse } from '../../utils/test-helpers.js';
+
+describe('Create Conversation Entry', () => {
+    let mockServer;
+
+    beforeEach(() => {
+        mockServer = createMockLettaServer();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Tool Definition', () => {
+        it('should have correct tool definition', () => {
+            expect(createConversationEntryDefinition.name).toBe('create_conversation_entry');
+            expect(createConversationEntryDefinition.description).toContain(
+                "Store a conversation entry in an agent's archival memory",
+            );
+            expect(createConversationEntryDefinition.inputSchema.required).toEqual([
+                'agent_id',
+                'role',
+                'content',
+            ]);
+            expect(createConversationEntryDefinition.inputSchema.properties).toHaveProperty(
+                'agent_id',
+            );
+            expect(createConversationEntryDefinition.inputSchema.properties).toHaveProperty('role');
+            expect(createConversationEntryDefinition.inputSchema.properties).toHaveProperty(
+                'content',
+            );
+            expect(createConversationEntryDefinition.inputSchema.properties).toHaveProperty(
+                'timestamp',
+            );
+            expect(createConversationEntryDefinition.inputSchema.properties).toHaveProperty(
+                'source',
+            );
+            expect(createConversationEntryDefinition.inputSchema.properties).toHaveProperty(
+                'session_id',
+            );
+            expect(createConversationEntryDefinition.inputSchema.properties.role.enum).toEqual([
+                'user',
+                'assistant',
+                'system',
+            ]);
+        });
+    });
+
+    describe('Functionality Tests', () => {
+        it('should create user conversation entry successfully', async () => {
+            const agentId = 'agent-123';
+            const content = 'Hello, this is a test message from the user.';
+
+            const mockPassage = {
+                id: 'passage-123',
+                text: expect.any(String),
+                embedding: [0.1, 0.2, 0.3],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: content,
+            });
+
+            // Verify API call
+            expect(mockServer.api.post).toHaveBeenCalledWith(
+                `/agents/${agentId}/archival-memory`,
+                expect.objectContaining({
+                    text: expect.stringContaining('"role":"user"'),
+                }),
+                expect.objectContaining({
+                    headers: expect.any(Object),
+                }),
+            );
+
+            // Verify the stored text is JSON with correct format
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.message_type).toBe('user_message');
+            expect(storedData.role).toBe('user');
+            expect(storedData.text).toBe(content);
+
+            // Verify response
+            const data = expectValidToolResponse(result);
+            expect(data.success).toBe(true);
+            expect(data.passage_id).toBe('passage-123');
+            expect(data.role).toBe('user');
+        });
+
+        it('should create assistant conversation entry successfully', async () => {
+            const agentId = 'agent-456';
+            const content = 'This is the assistant response.';
+
+            const mockPassage = {
+                id: 'passage-456',
+                text: expect.any(String),
+                embedding: [0.1, 0.2],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'assistant',
+                content: content,
+            });
+
+            // Verify the stored text has correct message_type
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.message_type).toBe('assistant_message');
+            expect(storedData.role).toBe('assistant');
+            expect(storedData.text).toBe(content);
+
+            const data = expectValidToolResponse(result);
+            expect(data.role).toBe('assistant');
+        });
+
+        it('should create system conversation entry successfully', async () => {
+            const agentId = 'agent-789';
+            const content = 'System notification message.';
+
+            const mockPassage = {
+                id: 'passage-789',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'system',
+                content: content,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.message_type).toBe('system_message');
+            expect(storedData.role).toBe('system');
+
+            const data = expectValidToolResponse(result);
+            expect(data.role).toBe('system');
+        });
+
+        it('should include custom timestamp', async () => {
+            const agentId = 'agent-ts';
+            const customTimestamp = '2024-06-15T10:30:00Z';
+
+            const mockPassage = {
+                id: 'passage-ts',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'Timestamped message',
+                timestamp: customTimestamp,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.date).toBe(customTimestamp);
+
+            const data = expectValidToolResponse(result);
+            expect(data.timestamp).toBe(customTimestamp);
+        });
+
+        it('should include source metadata', async () => {
+            const agentId = 'agent-source';
+            const source = 'claude_code';
+
+            const mockPassage = {
+                id: 'passage-source',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'Message from Claude Code',
+                source: source,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.source).toBe(source);
+
+            const data = expectValidToolResponse(result);
+            expect(data.source).toBe(source);
+        });
+
+        it('should include session_id metadata', async () => {
+            const agentId = 'agent-session';
+            const sessionId = 'session-12345';
+
+            const mockPassage = {
+                id: 'passage-session',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'assistant',
+                content: 'Session message',
+                session_id: sessionId,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.session_id).toBe(sessionId);
+
+            expectValidToolResponse(result);
+        });
+
+        it('should include all optional fields', async () => {
+            const agentId = 'agent-all';
+            const content = 'Full metadata message';
+            const timestamp = '2024-01-15T12:00:00Z';
+            const source = 'letta_ade';
+            const sessionId = 'session-full-123';
+
+            const mockPassage = {
+                id: 'passage-all',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: content,
+                timestamp: timestamp,
+                source: source,
+                session_id: sessionId,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.date).toBe(timestamp);
+            expect(storedData.source).toBe(source);
+            expect(storedData.session_id).toBe(sessionId);
+            expect(storedData.text).toBe(content);
+            expect(storedData.role).toBe('user');
+            expect(storedData.message_type).toBe('user_message');
+
+            const data = expectValidToolResponse(result);
+            expect(data.timestamp).toBe(timestamp);
+            expect(data.source).toBe(source);
+        });
+
+        it('should use defaults for optional fields', async () => {
+            const agentId = 'agent-defaults';
+
+            const mockPassage = {
+                id: 'passage-defaults',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'Minimal message',
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.source).toBe('unknown');
+            expect(storedData.session_id).toBe('no-session');
+            expect(storedData.date).toBeDefined(); // Should have auto-generated timestamp
+        });
+
+        it('should strip embeddings from response', async () => {
+            const agentId = 'agent-embed';
+
+            const mockPassage = {
+                id: 'passage-embed',
+                text: expect.any(String),
+                embedding: [0.1, 0.2, 0.3, 0.4, 0.5],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'Test message',
+            });
+
+            // Response should not contain embedding
+            const data = expectValidToolResponse(result);
+            expect(data.embedding).toBeUndefined();
+        });
+
+        it('should handle special characters in content', async () => {
+            const agentId = 'agent-special';
+            const specialContent =
+                'Special chars: \n\t"quotes" \'apostrophes\' & symbols < > {} 🚀💬 中文';
+
+            const mockPassage = {
+                id: 'passage-special',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: specialContent,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.text).toBe(specialContent);
+
+            expectValidToolResponse(result);
+        });
+
+        it('should handle very long content', async () => {
+            const agentId = 'agent-long';
+            const longContent = 'A'.repeat(10000);
+
+            const mockPassage = {
+                id: 'passage-long',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'assistant',
+                content: longContent,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.text).toBe(longContent);
+
+            expectValidToolResponse(result);
+        });
+
+        it('should handle special characters in agent ID', async () => {
+            const agentId = 'agent@special#id';
+            const encodedAgentId = encodeURIComponent(agentId);
+
+            const mockPassage = {
+                id: 'passage-encoded',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'Test',
+            });
+
+            expect(mockServer.api.post).toHaveBeenCalledWith(
+                `/agents/${encodedAgentId}/archival-memory`,
+                expect.any(Object),
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('should handle missing agent_id', async () => {
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    role: 'user',
+                    content: 'Test',
+                }),
+            ).rejects.toThrow('Missing required argument: agent_id');
+        });
+
+        it('should handle missing role', async () => {
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    agent_id: 'agent-123',
+                    content: 'Test',
+                }),
+            ).rejects.toThrow('Missing required argument: role');
+        });
+
+        it('should handle missing content', async () => {
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    agent_id: 'agent-123',
+                    role: 'user',
+                }),
+            ).rejects.toThrow('Missing required argument: content');
+        });
+
+        it('should handle null args', async () => {
+            await expect(handleCreateConversationEntry(mockServer, null)).rejects.toThrow(
+                'Missing required argument: agent_id',
+            );
+        });
+
+        it('should handle 404 agent not found error', async () => {
+            const error = new Error('Not found');
+            error.response = {
+                status: 404,
+                data: { error: 'Agent not found' },
+            };
+            mockServer.api.post.mockRejectedValueOnce(error);
+
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    agent_id: 'non-existent-agent',
+                    role: 'user',
+                    content: 'Test',
+                }),
+            ).rejects.toThrow();
+
+            expect(mockServer.createErrorResponse).toHaveBeenCalledWith(error);
+        });
+
+        it('should handle generic API errors', async () => {
+            const error = new Error('Internal server error');
+            error.response = {
+                status: 500,
+                data: { error: 'Database error' },
+            };
+            mockServer.api.post.mockRejectedValueOnce(error);
+
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    agent_id: 'agent-123',
+                    role: 'user',
+                    content: 'Test',
+                }),
+            ).rejects.toThrow();
+
+            expect(mockServer.createErrorResponse).toHaveBeenCalledWith(error);
+        });
+
+        it('should handle network errors without response', async () => {
+            const error = new Error('Network error: Connection refused');
+            mockServer.api.post.mockRejectedValueOnce(error);
+
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    agent_id: 'agent-123',
+                    role: 'user',
+                    content: 'Test',
+                }),
+            ).rejects.toThrow();
+
+            expect(mockServer.createErrorResponse).toHaveBeenCalledWith(error);
+        });
+    });
+
+    describe('Edge Cases', () => {
+        it('should handle UUID format agent IDs', async () => {
+            const agentId = '550e8400-e29b-41d4-a716-446655440000';
+
+            const mockPassage = {
+                id: 'passage-uuid',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'UUID test',
+            });
+
+            expect(mockServer.api.post).toHaveBeenCalledWith(
+                `/agents/${agentId}/archival-memory`,
+                expect.any(Object),
+                expect.any(Object),
+            );
+        });
+
+        it('should reject empty content string', async () => {
+            await expect(
+                handleCreateConversationEntry(mockServer, {
+                    agent_id: 'agent-empty',
+                    role: 'user',
+                    content: '',
+                }),
+            ).rejects.toThrow('Missing required argument: content');
+        });
+
+        it('should handle multiline content', async () => {
+            const agentId = 'agent-multiline';
+            const multilineContent = `Line 1: Introduction
+Line 2: Main content
+Line 3: Additional details
+
+Line 5: After blank line
+\tLine 6: With tab
+  Line 7: With spaces`;
+
+            const mockPassage = {
+                id: 'passage-multiline',
+                text: expect.any(String),
+                embedding: [0.1],
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: multilineContent,
+            });
+
+            const callArgs = mockServer.api.post.mock.calls[0][1];
+            const storedData = JSON.parse(callArgs.text);
+            expect(storedData.text).toBe(multilineContent);
+
+            expectValidToolResponse(result);
+        });
+
+        it('should handle passage with null embedding', async () => {
+            const agentId = 'agent-null-embed';
+
+            const mockPassage = {
+                id: 'passage-null-embed',
+                text: expect.any(String),
+                embedding: null,
+            };
+
+            mockServer.api.post.mockResolvedValueOnce({ data: mockPassage });
+
+            const result = await handleCreateConversationEntry(mockServer, {
+                agent_id: agentId,
+                role: 'user',
+                content: 'Test',
+            });
+
+            // Should not error even with null embedding
+            expectValidToolResponse(result);
+        });
+    });
+});

--- a/src/test/tools/messages/list-messages.test.js
+++ b/src/test/tools/messages/list-messages.test.js
@@ -1,0 +1,458 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    handleListMessages,
+    listMessagesDefinition,
+} from '../../../tools/messages/list-messages.js';
+import { createMockLettaServer } from '../../utils/mock-server.js';
+import { expectValidToolResponse } from '../../utils/test-helpers.js';
+
+describe('List Messages', () => {
+    let mockServer;
+
+    beforeEach(() => {
+        mockServer = createMockLettaServer();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('Tool Definition', () => {
+        it('should have correct tool definition', () => {
+            expect(listMessagesDefinition.name).toBe('list_messages');
+            expect(listMessagesDefinition.description).toContain(
+                "Retrieve messages from an agent's conversation history",
+            );
+            expect(listMessagesDefinition.inputSchema.required).toEqual(['agent_id']);
+            expect(listMessagesDefinition.inputSchema.properties).toHaveProperty('agent_id');
+            expect(listMessagesDefinition.inputSchema.properties).toHaveProperty('limit');
+            expect(listMessagesDefinition.inputSchema.properties).toHaveProperty('order');
+            expect(listMessagesDefinition.inputSchema.properties).toHaveProperty('before');
+            expect(listMessagesDefinition.inputSchema.properties).toHaveProperty('after');
+            expect(listMessagesDefinition.inputSchema.properties).toHaveProperty('group_id');
+            expect(listMessagesDefinition.inputSchema.properties.order.enum).toEqual([
+                'asc',
+                'desc',
+            ]);
+        });
+    });
+
+    describe('Functionality Tests', () => {
+        it('should list messages successfully', async () => {
+            const agentId = 'agent-123';
+            const mockMessages = [
+                {
+                    id: 'msg-1',
+                    message_type: 'user_message',
+                    date: '2024-01-01T00:00:00Z',
+                    role: 'user',
+                    text: 'Hello agent',
+                },
+                {
+                    id: 'msg-2',
+                    message_type: 'assistant_message',
+                    date: '2024-01-01T00:00:01Z',
+                    role: 'assistant',
+                    text: 'Hello! How can I help you?',
+                },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+            });
+
+            // Verify API call
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    headers: expect.any(Object),
+                    params: {},
+                }),
+            );
+
+            // Verify response
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toHaveLength(2);
+            expect(data.count).toBe(2);
+            expect(data.messages[0].id).toBe('msg-1');
+            expect(data.messages[0].role).toBe('user');
+            expect(data.messages[1].role).toBe('assistant');
+        });
+
+        it('should handle limit parameter', async () => {
+            const agentId = 'agent-limit';
+            const limit = 10;
+            const mockMessages = Array.from({ length: 10 }, (_, i) => ({
+                id: `msg-${i}`,
+                message_type: 'user_message',
+                text: `Message ${i}`,
+            }));
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                limit: limit,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: { limit: limit },
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toHaveLength(10);
+            expect(data.count).toBe(10);
+        });
+
+        it('should handle order parameter asc', async () => {
+            const agentId = 'agent-asc';
+            const mockMessages = [
+                { id: 'msg-old', date: '2024-01-01T00:00:00Z', text: 'Oldest' },
+                { id: 'msg-new', date: '2024-01-02T00:00:00Z', text: 'Newest' },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                order: 'asc',
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: { order: 'asc' },
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages[0].id).toBe('msg-old');
+        });
+
+        it('should handle order parameter desc', async () => {
+            const agentId = 'agent-desc';
+            const mockMessages = [
+                { id: 'msg-new', date: '2024-01-02T00:00:00Z', text: 'Newest' },
+                { id: 'msg-old', date: '2024-01-01T00:00:00Z', text: 'Oldest' },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                order: 'desc',
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: { order: 'desc' },
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages[0].id).toBe('msg-new');
+        });
+
+        it('should handle before parameter', async () => {
+            const agentId = 'agent-before';
+            const beforeId = 'msg-50';
+            const mockMessages = [
+                { id: 'msg-48', text: 'Before msg 50' },
+                { id: 'msg-49', text: 'Before msg 50' },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                before: beforeId,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: { before: beforeId },
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toHaveLength(2);
+        });
+
+        it('should handle after parameter', async () => {
+            const agentId = 'agent-after';
+            const afterId = 'msg-100';
+            const mockMessages = [
+                { id: 'msg-101', text: 'After msg 100' },
+                { id: 'msg-102', text: 'After msg 101' },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                after: afterId,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: { after: afterId },
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages[0].id).toBe('msg-101');
+        });
+
+        it('should handle group_id parameter', async () => {
+            const agentId = 'agent-group';
+            const groupId = 'group-123';
+            const mockMessages = [
+                { id: 'msg-1', group_id: groupId, text: 'Message in group' },
+                { id: 'msg-2', group_id: groupId, text: 'Another message in group' },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                group_id: groupId,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: { group_id: groupId },
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toHaveLength(2);
+        });
+
+        it('should handle all parameters combined', async () => {
+            const agentId = 'agent-all';
+            const params = {
+                limit: 5,
+                order: 'desc',
+                before: 'msg-20',
+                after: 'msg-10',
+                group_id: 'group-456',
+            };
+
+            const mockMessages = [{ id: 'msg-15', text: 'Message in range' }];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+                ...params,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: params,
+                }),
+            );
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toHaveLength(1);
+        });
+
+        it('should handle empty message list', async () => {
+            const agentId = 'agent-empty';
+            mockServer.api.get.mockResolvedValueOnce({ data: [] });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+            });
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toEqual([]);
+            expect(data.count).toBe(0);
+        });
+
+        it('should handle messages with tool calls', async () => {
+            const agentId = 'agent-tools';
+            const mockMessages = [
+                {
+                    id: 'msg-1',
+                    message_type: 'tool_call',
+                    role: 'assistant',
+                    tool_calls: [
+                        {
+                            function: { name: 'search', arguments: '{"query": "test"}' },
+                        },
+                    ],
+                },
+                {
+                    id: 'msg-2',
+                    message_type: 'tool_return',
+                    role: 'tool',
+                    tool_call_id: 'call-123',
+                    content: 'Search results here',
+                },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+            });
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages).toHaveLength(2);
+            expect(data.messages[0].message_type).toBe('tool_call');
+            expect(data.messages[1].message_type).toBe('tool_return');
+        });
+
+        it('should handle special characters in agent ID', async () => {
+            const agentId = 'agent@special#id';
+            const encodedAgentId = encodeURIComponent(agentId);
+
+            mockServer.api.get.mockResolvedValueOnce({ data: [] });
+
+            await handleListMessages(mockServer, {
+                agent_id: agentId,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${encodedAgentId}/messages`,
+                expect.any(Object),
+            );
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('should handle missing agent_id', async () => {
+            await expect(handleListMessages(mockServer, {})).rejects.toThrow(
+                'Missing required argument: agent_id',
+            );
+        });
+
+        it('should handle null args', async () => {
+            await expect(handleListMessages(mockServer, null)).rejects.toThrow(
+                'Missing required argument: agent_id',
+            );
+        });
+
+        it('should handle 404 agent not found error', async () => {
+            const agentId = 'non-existent-agent';
+            const error = new Error('Not found');
+            error.response = {
+                status: 404,
+                data: { error: 'Agent not found' },
+            };
+            mockServer.api.get.mockRejectedValueOnce(error);
+
+            await expect(
+                handleListMessages(mockServer, {
+                    agent_id: agentId,
+                }),
+            ).rejects.toThrow();
+
+            expect(mockServer.createErrorResponse).toHaveBeenCalledWith(error);
+        });
+
+        it('should handle generic API errors', async () => {
+            const error = new Error('Internal server error');
+            error.response = {
+                status: 500,
+                data: { error: 'Database error' },
+            };
+            mockServer.api.get.mockRejectedValueOnce(error);
+
+            await expect(
+                handleListMessages(mockServer, {
+                    agent_id: 'agent-123',
+                }),
+            ).rejects.toThrow();
+
+            expect(mockServer.createErrorResponse).toHaveBeenCalledWith(error);
+        });
+
+        it('should handle network errors without response', async () => {
+            const error = new Error('Network error: Connection refused');
+            mockServer.api.get.mockRejectedValueOnce(error);
+
+            await expect(
+                handleListMessages(mockServer, {
+                    agent_id: 'agent-123',
+                }),
+            ).rejects.toThrow();
+
+            expect(mockServer.createErrorResponse).toHaveBeenCalledWith(error);
+        });
+    });
+
+    describe('Edge Cases', () => {
+        it('should handle UUID format agent IDs', async () => {
+            const agentId = '550e8400-e29b-41d4-a716-446655440000';
+            mockServer.api.get.mockResolvedValueOnce({ data: [] });
+
+            await handleListMessages(mockServer, {
+                agent_id: agentId,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.any(Object),
+            );
+        });
+
+        it('should not include undefined parameters in API call', async () => {
+            const agentId = 'agent-undefined';
+            mockServer.api.get.mockResolvedValueOnce({ data: [] });
+
+            await handleListMessages(mockServer, {
+                agent_id: agentId,
+                limit: undefined,
+                order: undefined,
+                before: undefined,
+                after: undefined,
+                group_id: undefined,
+            });
+
+            expect(mockServer.api.get).toHaveBeenCalledWith(
+                `/agents/${agentId}/messages`,
+                expect.objectContaining({
+                    params: {},
+                }),
+            );
+        });
+
+        it('should handle messages with complex content', async () => {
+            const agentId = 'agent-complex';
+            const mockMessages = [
+                {
+                    id: 'msg-complex',
+                    message_type: 'user_message',
+                    role: 'user',
+                    text: 'Special chars: \n\t"quotes" \'apostrophes\' & symbols < > {} 🚀💬',
+                    metadata: {
+                        nested: { value: 'test' },
+                        array: [1, 2, 3],
+                    },
+                },
+            ];
+
+            mockServer.api.get.mockResolvedValueOnce({ data: mockMessages });
+
+            const result = await handleListMessages(mockServer, {
+                agent_id: agentId,
+            });
+
+            const data = expectValidToolResponse(result);
+            expect(data.messages[0].text).toContain('🚀');
+            expect(data.messages[0].metadata.nested.value).toBe('test');
+        });
+    });
+});

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -70,6 +70,10 @@ import {
 import { handleListPrompts, listPromptsToolDefinition } from './prompts/list-prompts.js';
 import { handleUsePrompt, usePromptToolDefinition } from './prompts/use-prompt.js';
 
+// Message-related imports
+import { handleListMessages, listMessagesDefinition } from './messages/list-messages.js';
+import { handleCreateConversationEntry, createConversationEntryDefinition } from './messages/create-conversation-entry.js';
+
 import {
     CallToolRequestSchema,
     ListToolsRequestSchema,
@@ -116,6 +120,8 @@ export function registerToolHandlers(server) {
         addMcpToolToLettaDefinition,
         listPromptsToolDefinition,
         usePromptToolDefinition,
+        listMessagesDefinition,
+        createConversationEntryDefinition,
     ];
 
     // Enhance all tools with output schemas and improved descriptions
@@ -191,6 +197,10 @@ export function registerToolHandlers(server) {
                 return handleListPrompts(server, request.params.arguments);
             case 'use_prompt':
                 return handleUsePrompt(server, request.params.arguments);
+            case 'list_messages':
+                return handleListMessages(server, request.params.arguments);
+            case 'create_conversation_entry':
+                return handleCreateConversationEntry(server, request.params.arguments);
             default:
                 throw new McpError(
                     ErrorCode.MethodNotFound,
@@ -233,6 +243,8 @@ export const toolDefinitions = enhanceAllTools([
     addMcpToolToLettaDefinition,
     listPromptsToolDefinition,
     usePromptToolDefinition,
+    listMessagesDefinition,
+    createConversationEntryDefinition,
 ]);
 
 // Export all tool handlers
@@ -266,4 +278,6 @@ export const toolHandlers = {
     handleGetAgentSummary,
     handleBulkDeleteAgents,
     handleAddMcpToolToLetta,
+    handleListMessages,
+    handleCreateConversationEntry,
 };

--- a/src/tools/messages/create-conversation-entry.js
+++ b/src/tools/messages/create-conversation-entry.js
@@ -1,0 +1,119 @@
+/**
+ * Tool handler for creating a conversation entry in archival memory
+ *
+ * Since Letta doesn't have a direct API to add messages to history without
+ * triggering agent processing, this stores conversation entries as archival
+ * passages with consistent formatting and tags for searchability.
+ */
+export async function handleCreateConversationEntry(server, args) {
+    if (!args?.agent_id) {
+        throw new Error('Missing required argument: agent_id');
+    }
+    if (!args?.role) {
+        throw new Error('Missing required argument: role');
+    }
+    if (!args?.content) {
+        throw new Error('Missing required argument: content');
+    }
+
+    try {
+        const headers = server.getApiHeaders();
+        const agentId = encodeURIComponent(args.agent_id);
+
+        // Format the conversation entry to match Letta's message structure
+        const timestamp = args.timestamp || new Date().toISOString();
+        const source = args.source || 'unknown';
+        const sessionId = args.session_id || 'no-session';
+
+        // Map role to Letta message_type
+        const messageTypeMap = {
+            user: 'user_message',
+            assistant: 'assistant_message',
+            system: 'system_message',
+        };
+
+        // Create JSON structure matching Letta message format
+        const messageEntry = {
+            message_type: messageTypeMap[args.role] || 'user_message',
+            date: timestamp,
+            role: args.role,
+            text: args.content,
+            source: source,
+            session_id: sessionId,
+        };
+
+        // Store as JSON for consistent parsing and search
+        const entryText = JSON.stringify(messageEntry);
+
+        // Create the passage
+        const response = await server.api.post(
+            `/agents/${agentId}/archival-memory`,
+            { text: entryText },
+            { headers },
+        );
+
+        // Strip embeddings from response
+        const passage = response.data;
+        if (passage.embedding) {
+            delete passage.embedding;
+        }
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify({
+                        success: true,
+                        passage_id: passage.id,
+                        timestamp: timestamp,
+                        role: args.role,
+                        source: source,
+                    }),
+                },
+            ],
+        };
+    } catch (error) {
+        return server.createErrorResponse(error);
+    }
+}
+
+/**
+ * Tool definition for create_conversation_entry
+ */
+export const createConversationEntryDefinition = {
+    name: 'create_conversation_entry',
+    description:
+        "Store a conversation entry in an agent's archival memory. Use this to record conversations from external sources (like Claude Code sessions) that should be searchable via search_archival_memory. Entries are formatted with metadata for easy filtering.",
+    inputSchema: {
+        type: 'object',
+        properties: {
+            agent_id: {
+                type: 'string',
+                description: 'ID of the agent to store the conversation entry for',
+            },
+            role: {
+                type: 'string',
+                enum: ['user', 'assistant', 'system'],
+                description: 'Role of the message sender',
+            },
+            content: {
+                type: 'string',
+                description: 'The message content',
+            },
+            timestamp: {
+                type: 'string',
+                format: 'date-time',
+                description: 'ISO 8601 timestamp of the message (defaults to now)',
+            },
+            source: {
+                type: 'string',
+                description: 'Source of the conversation (e.g., "claude_code", "letta_ade")',
+            },
+            session_id: {
+                type: 'string',
+                description: 'Session identifier for grouping related messages',
+            },
+        },
+        required: ['agent_id', 'role', 'content'],
+    },
+};

--- a/src/tools/messages/list-messages.js
+++ b/src/tools/messages/list-messages.js
@@ -1,0 +1,80 @@
+/**
+ * Tool handler for listing messages from an agent's conversation history
+ */
+export async function handleListMessages(server, args) {
+    if (!args?.agent_id) {
+        throw new Error('Missing required argument: agent_id');
+    }
+
+    try {
+        const headers = server.getApiHeaders();
+        const agentId = encodeURIComponent(args.agent_id);
+
+        // Construct query parameters
+        const params = {};
+        if (args.limit) params.limit = args.limit;
+        if (args.order) params.order = args.order;
+        if (args.before) params.before = args.before;
+        if (args.after) params.after = args.after;
+        if (args.group_id) params.group_id = args.group_id;
+
+        const response = await server.api.get(`/agents/${agentId}/messages`, {
+            headers,
+            params,
+        });
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify({
+                        messages: response.data,
+                        count: response.data.length,
+                    }),
+                },
+            ],
+        };
+    } catch (error) {
+        return server.createErrorResponse(error);
+    }
+}
+
+/**
+ * Tool definition for list_messages
+ */
+export const listMessagesDefinition = {
+    name: 'list_messages',
+    description:
+        "Retrieve messages from an agent's conversation history. Returns paginated message history including user messages, assistant responses, tool calls, and system messages. Use for reviewing past conversations or debugging agent behavior.",
+    inputSchema: {
+        type: 'object',
+        properties: {
+            agent_id: {
+                type: 'string',
+                description: 'ID of the agent whose messages to retrieve',
+            },
+            limit: {
+                type: 'integer',
+                description: 'Maximum number of messages to return',
+            },
+            order: {
+                type: 'string',
+                enum: ['asc', 'desc'],
+                description: 'Sort order: "asc" for oldest first, "desc" for newest first',
+            },
+            before: {
+                type: 'string',
+                description: 'Pagination cursor - get messages before this message ID',
+            },
+            after: {
+                type: 'string',
+                description: 'Pagination cursor - get messages after this message ID',
+            },
+            group_id: {
+                type: 'string',
+                description: 'Filter messages by group ID',
+            },
+        },
+        required: ['agent_id'],
+    },
+};


### PR DESCRIPTION
## Summary
- Add `list_messages` tool to retrieve paginated conversation history from agents
- Add `create_conversation_entry` tool to store external conversations as archival passages
- Include comprehensive tests (44 total) for both tools

## Test plan
- [x] All 44 tests pass locally
- [x] Docker image builds successfully
- [x] Tools load correctly via MCP gateway (35 tools total)
- [x] `list_messages` tested via gateway - returns conversation history
- [x] `create_conversation_entry` tested via gateway - stores entry in archival memory

**Note**: `create_conversation_entry` stores entries as archival passages since Letta's API doesn't support direct message insertion. Entries are formatted as JSON with metadata for searchability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List agent messages with filtering (before/after), ordering, limits, and session/group options
  * Create and store conversation entries in agent archival memory with metadata (timestamp, source, session)

* **Tests**
  * Comprehensive test coverage for both messaging tools, including validation, error paths, edge cases, and response shaping

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->