### PR TITLE
🔒 Fix permissive CORS configuration in Docker Compose and Nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,17 @@ PORT=6507
 # Existing local setups often use LETTA_PASSWORD.
 # LETTA_PASSWORD=your-password
 
+
+# ============================================================================
+# SECURITY CONFIGURATION
+# ============================================================================
+
+# Allowed origins for CORS (Cross-Origin Resource Sharing)
+# Used by both the Rust server and the Nginx proxy to restrict access
+# Default: http://localhost:3000
+# Example: https://myapp.example.com
+# CORS_ALLOWED_ORIGINS=http://localhost:3000
+
 # ============================================================================
 # LOGGING & DEBUGGING
 # ============================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2323,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2669,7 +2669,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2727,7 +2727,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4177,7 +4177,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,8 +13,8 @@ services:
             # Internal server port
             PORT: 6507
 
-            # CORS configuration - allow all origins for development
-            CORS_ALLOWED_ORIGINS: '*'
+            # CORS configuration - allow specified origins, defaulting to localhost for development
+            CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
 
             # Optional - Rust logging
             RUST_LOG: ${RUST_LOG:-debug}
@@ -36,8 +36,10 @@ services:
         restart: unless-stopped
         ports:
             - '3001:3001'
+        environment:
+            - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
         volumes:
-            - ./rust/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+            - ./rust/nginx.conf:/etc/nginx/templates/default.conf.template:ro
         depends_on:
             letta-mcp-rust:
                 condition: service_healthy

--- a/rust/nginx.conf
+++ b/rust/nginx.conf
@@ -48,7 +48,7 @@ server {
         proxy_read_timeout 300s;
 
         # CORS headers
-        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Origin' '${CORS_ALLOWED_ORIGINS}' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
         add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
 


### PR DESCRIPTION
🎯 **What:**
The Docker Compose setup for the Letta MCP server previously used a wildcard (`*`) for `CORS_ALLOWED_ORIGINS`, allowing any origin to make cross-origin requests to the server. Additionally, the Nginx configuration hardcoded the `Access-Control-Allow-Origin: *` header, completely bypassing any server-level CORS restrictions.

⚠️ **Risk:**
A wildcard CORS configuration allows malicious websites to perform cross-origin attacks (like CSRF or reading sensitive data) if a user running the server visits the attacker's site. For a tool like an MCP server that may have access to local files or other tools, this is a significant security risk.

🛡️ **Solution:**
1. Parameterized `CORS_ALLOWED_ORIGINS` in `compose.yaml` to allow developers to configure the allowed origins via `.env`.
2. Changed the default `CORS_ALLOWED_ORIGINS` value to a restrictive `http://localhost:3000`, which is a common frontend development port, rather than `*`.
3. Updated `rust/nginx.conf` to dynamically use the `CORS_ALLOWED_ORIGINS` environment variable instead of hardcoding `*`. This required modifying the volume mount in `compose.yaml` from `conf.d` to `templates` so the Nginx Alpine image will perform environment variable substitution on startup.
4. Added documentation to `.env.example` explaining how to configure the allowed origins.

---
*PR created automatically by Jules for task [15991934366405244521](https://jules.google.com/task/15991934366405244521) started by @oculairmedia*