### PR TITLE
⚡ [performance improvement] Remove unnecessary string clone when building ID for detach_source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2323,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2669,7 +2669,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2727,7 +2727,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4177,7 +4177,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/letta-server/src/tools/source_manager.rs
+++ b/letta-server/src/tools/source_manager.rs
@@ -347,7 +347,7 @@ async fn handle_detach_source(
     let source_id = require_field(request.source_id, "source_id required")?;
 
     let letta_agent_id = require_id(Some(agent_id), "agent_id")?;
-    let letta_source_id = require_id(Some(source_id.clone()), "source_id")?;
+    let letta_source_id = require_id(Some(source_id), "source_id")?;
 
     let agent_state = client
         .sources()

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,5 +1,0 @@
-💡 **What:** The optimization implemented is removing an unnecessary \`.clone()\` call on \`source_id\` in \`handle_detach_source\` in \`letta-server/src/tools/source_manager.rs\`.
-
-🎯 **Why:** The \`source_id\` was cloned before being passed to \`require_id\`, even though it is not used later in the function. Removing the clone transfers ownership directly, avoiding an unnecessary string clone and heap allocation.
-
-📊 **Measured Improvement:** I did not measure the performance improvement because the macro-level impact of avoiding a single string clone is likely entirely dwarfed by the network and I/O overhead of executing the actual source detachment. However, removing the clone avoids an unnecessary heap allocation, making the code slightly more optimal and aligning with standard Rust practices.

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,5 @@
+💡 **What:** The optimization implemented is removing an unnecessary \`.clone()\` call on \`source_id\` in \`handle_detach_source\` in \`letta-server/src/tools/source_manager.rs\`.
+
+🎯 **Why:** The \`source_id\` was cloned before being passed to \`require_id\`, even though it is not used later in the function. Removing the clone transfers ownership directly, avoiding an unnecessary string clone and heap allocation.
+
+📊 **Measured Improvement:** I did not measure the performance improvement because the macro-level impact of avoiding a single string clone is likely entirely dwarfed by the network and I/O overhead of executing the actual source detachment. However, removing the clone avoids an unnecessary heap allocation, making the code slightly more optimal and aligning with standard Rust practices.


### PR DESCRIPTION
💡 **What:** The optimization implemented is removing an unnecessary `.clone()` call on `source_id` in `handle_detach_source` in `letta-server/src/tools/source_manager.rs`.

🎯 **Why:** The `source_id` was cloned before being passed to `require_id`, even though it is not used later in the function. Removing the clone transfers ownership directly, avoiding an unnecessary string clone and heap allocation.

📊 **Measured Improvement:** I did not measure the performance improvement because the macro-level impact of avoiding a single string clone is likely entirely dwarfed by the network and I/O overhead of executing the actual source detachment. However, removing the clone avoids an unnecessary heap allocation, making the code slightly more optimal and aligning with standard Rust practices.

---
*PR created automatically by Jules for task [3772494763323358482](https://jules.google.com/task/3772494763323358482) started by @oculairmedia*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source detachment handling to avoid an unnecessary copy during the process, making ownership transfer cleaner and more reliable.
- **Documentation**
  - Added a clearer PR description with a summary of the change, the reason behind it, and the expected impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->