### PR TITLE
style: rustfmt common.rs to fix red master CI

### DIFF
--- a/rust/vendor/letta/src/types/common.rs
+++ b/rust/vendor/letta/src/types/common.rs
@@ -160,7 +160,9 @@ impl FromStr for LettaId {
                 && !prefix.ends_with('-')
                 && prefix.chars().any(|c| c.is_alphanumeric())
                 && suffix.chars().any(|c| c.is_alphanumeric())
-                && prefix.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+                && prefix
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
                 && suffix.chars().all(|c| c.is_alphanumeric() || c == '_')
             {
                 return Ok(Self::new_raw(prefix, suffix));


### PR DESCRIPTION
Master is red: `cargo fmt --all -- --check` fails on `rust/vendor/letta/src/types/common.rs:160` — a line-width violation in the short-ID prefix validation from #161.

Fork PR #161 never ran the Rust CI (fork PRs require approval to run workflows), so this wasn't caught pre-merge. Applies `cargo fmt` — formatting-only, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)